### PR TITLE
Add workaround to ensure `npm install` does not fail if ran repeatedly.

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,8 @@
     "cypress:open": "cypress open",
     "cypress:run": "cypress run",
     "storybook": "start-storybook -s ./public -p 6006",
-    "build-storybook": "build-storybook"
+    "build-storybook": "build-storybook",
+    "preinstall": "rm -rf node_modules/websocket/.git"
   },
   "jest": {
     "collectCoverageFrom": [


### PR DESCRIPTION
Cannot solve actual issue without contribution to @purser/metamask,
where this issue originates.

Before creating this workaround, checked if fixed in metamask@2.4.1
(nope).

Note: This only works with "npm install" not "npm install package".