### PR TITLE
fix missing strings in header (sign in/up)

### DIFF
--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -23,6 +23,8 @@
     "facebook": "Like us on Facebook",
     "slack": "Join us on Slack",
     "telegram": "Join us on Telegram",
+    "signin": "Sign In",
+    "signup": "Sign Up",
     "en": "English",
     "de": "German",
     "ru": "Russian"

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -141,12 +141,12 @@ class Header extends Component {
 
                   <li>
                    <Link onClick={() => this.closeNavbar()} to="/signin" className={styles.link}>
-                        {t('accounts.signin')}
+                        {t('header.signin')}
                     </Link>
                   </li>
                   <li>
                    <Link onClick={() => this.closeNavbar()} to="/signup" className={`${styles.link} ${styles.main}`}>
-                        {t('accounts.signup')}
+                        {t('header.signup')}
                     </Link>
                   </li>
 


### PR DESCRIPTION
Header was lacking two signin and signup strings causing the header to break flow.

Before:
![image](https://user-images.githubusercontent.com/101744/67941918-50991800-fbdf-11e9-8558-2ed2b5e21cd4.png)

After:
![image](https://user-images.githubusercontent.com/101744/67941860-3b23ee00-fbdf-11e9-9d7a-46d8edd2edee.png)
